### PR TITLE
Set default backup path for scirius in Amsterdam

### DIFF
--- a/src/templates/docker-compose.yml.j2
+++ b/src/templates/docker-compose.yml.j2
@@ -36,6 +36,7 @@ scirius:
     build: $basepath/docker/scirius
     volumes:
         - $basepath/config/scirius:/etc/scirius:ro
+        - $basepath/config/scirius/backups:/var/backups:ro
         - $basepath/config/suricata/suricata.yaml:/etc/suricata/suricata.yaml:ro
         - $basepath/scirius:/etc/suricata/rules:rw
         - $basepath/suricata/run:/var/run/suricata:ro

--- a/src/templates/docker-compose.yml.j2
+++ b/src/templates/docker-compose.yml.j2
@@ -36,7 +36,7 @@ scirius:
     build: $basepath/docker/scirius
     volumes:
         - $basepath/config/scirius:/etc/scirius:ro
-        - $basepath/config/scirius/backups:/var/backups:ro
+        - $basepath/backups:/var/backups:ro
         - $basepath/config/suricata/suricata.yaml:/etc/suricata/suricata.yaml:ro
         - $basepath/scirius:/etc/suricata/rules:rw
         - $basepath/suricata/run:/var/run/suricata:ro

--- a/src/templates/docker-compose.yml.j2
+++ b/src/templates/docker-compose.yml.j2
@@ -36,7 +36,7 @@ scirius:
     build: $basepath/docker/scirius
     volumes:
         - $basepath/config/scirius:/etc/scirius:ro
-        - $basepath/backups:/var/backups:ro
+        - $basepath/backups:/var/backups:rw
         - $basepath/config/suricata/suricata.yaml:/etc/suricata/suricata.yaml:ro
         - $basepath/scirius:/etc/suricata/rules:rw
         - $basepath/suricata/run:/var/run/suricata:ro


### PR DESCRIPTION
According to the Scirius readme the backups should go into: /var/backups

With default configuration file, the backup is done on disk in /var/backups but other methods are available.